### PR TITLE
[fix] H264 화면 송출 에러 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,5 +89,5 @@ jobs:
             docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/rtmp-server
             docker stop $(docker ps -a -q)
             docker rm $(docker ps -a -q)
-            docker run -d -p 1935:1935 --env-file ${{ secrets.ENV_PATH }} ${{ secrets.NCP_CONTAINER_REGISTRY }}/rtmp-server
+            docker run -d -p 1935:1935 -p 80:80 --env-file ${{ secrets.ENV_PATH }} ${{ secrets.NCP_CONTAINER_REGISTRY }}/rtmp-server
             docker image prune -f

--- a/server/rtmp-server/Dockerfile
+++ b/server/rtmp-server/Dockerfile
@@ -11,6 +11,8 @@ RUN npm i
 
 COPY ./server/rtmp-server/. .
 
-EXPOSE 1935
+RUN mv ./node_relay_session.js ./node_modules/node-media-server/src/node_relay_session.js
+
+EXPOSE 1935 80
 
 CMD ["node","app.js"]

--- a/server/rtmp-server/app.js
+++ b/server/rtmp-server/app.js
@@ -1,10 +1,6 @@
 require("dotenv").config();
-const NodeMediaServer = require("node-media-server");
-let exec = require('child_process').exec
 
-exec('node system_func.js', (err,out,stderr) => {
-  console.log(out)
-});
+const NodeMediaServer = require("node-media-server");
 
 const config = {
   rtmp: {
@@ -16,27 +12,20 @@ const config = {
   },
   http: {
     port: 80,
-    mediaroot: __dirname + "/media",
-    webroot: __dirname + "/www",
     allow_origin: "*",
-    api: true,
   },
-    trans: {
-      ffmpeg: "/usr/local/bin/ffmpeg",
-      tasks: [
-        {
-          app: "live",
-          vc: "copy",
-          vcParam: [],
-          ac: "aac",
-          acParam: ["-ab", "64k", "-ac", "1", "-ar", "44100"],
-          hls: true,
-          hlsFlags: "[hls_time=2:hls_list_size=3:hls_flags=delete_segments]",
-        },
-      ],
-    },
-
+  relay: {
+    ffmpeg: "/usr/local/bin/ffmpeg",
+    tasks: [
+      {
+        app: "live",
+        mode: "push",
+        edge: "rtmp://" + process.env.ENCODING_SERVER_HOST,
+      },
+    ],
+  },
 };
 
 const nms = new NodeMediaServer(config);
+
 nms.run();

--- a/server/rtmp-server/app.js
+++ b/server/rtmp-server/app.js
@@ -1,5 +1,10 @@
 require("dotenv").config();
 const NodeMediaServer = require("node-media-server");
+let exec = require('child_process').exec
+
+exec('node system_func.js', (err,out,stderr) => {
+  console.log(out)
+});
 
 const config = {
   rtmp: {
@@ -9,16 +14,28 @@ const config = {
     ping: 30,
     ping_timeout: 60,
   },
-  relay: {
-    ffmpeg: "/usr/local/bin/ffmpeg",
-    tasks: [
-      {
-        app: "live",
-        mode: "push",
-        edge: "rtmp://" + process.env.ENCODING_SERVER_HOST,
-      },
-    ],
+  http: {
+    port: 80,
+    mediaroot: __dirname + "/media",
+    webroot: __dirname + "/www",
+    allow_origin: "*",
+    api: true,
   },
+    trans: {
+      ffmpeg: "/usr/local/bin/ffmpeg",
+      tasks: [
+        {
+          app: "live",
+          vc: "copy",
+          vcParam: [],
+          ac: "aac",
+          acParam: ["-ab", "64k", "-ac", "1", "-ar", "44100"],
+          hls: true,
+          hlsFlags: "[hls_time=2:hls_list_size=3:hls_flags=delete_segments]",
+        },
+      ],
+    },
+
 };
 
 const nms = new NodeMediaServer(config);

--- a/server/rtmp-server/node_relay_session.js
+++ b/server/rtmp-server/node_relay_session.js
@@ -1,0 +1,81 @@
+//
+//  Created by Mingliang Chen on 18/3/16.
+//  illuspas[a]gmail.com
+//  Copyright (c) 2018 Nodemedia. All rights reserved.
+//
+const Logger = require("./node_core_logger");
+const NodeCoreUtils = require("./node_core_utils");
+
+const EventEmitter = require("events");
+const { spawn } = require("child_process");
+
+const RTSP_TRANSPORT = ["udp", "tcp", "udp_multicast", "http"];
+
+class NodeRelaySession extends EventEmitter {
+  constructor(conf) {
+    super();
+    this.conf = conf;
+    this.id = NodeCoreUtils.generateNewSessionID();
+    this.ts = (Date.now() / 1000) | 0;
+    this.TAG = "relay";
+  }
+
+  run() {
+    let format = this.conf.ouPath.startsWith("rtsp://") ? "rtsp" : "flv";
+    let argv = [
+      "-re",
+      "-i",
+      this.conf.inPath,
+      "-c:v",
+      "libx264",
+      "-preset",
+      "veryfast",
+      "-tune",
+      "zerolatency",
+      "-c:a",
+      "aac",
+      "-ar",
+      "44100",
+      "-f",
+      format,
+      this.conf.ouPath,
+    ];
+    if (this.conf.inPath[0] === "/" || this.conf.inPath[1] === ":") {
+      argv.unshift("-1");
+      argv.unshift("-stream_loop");
+    }
+
+    if (this.conf.inPath.startsWith("rtsp://") && this.conf.rtsp_transport) {
+      if (RTSP_TRANSPORT.indexOf(this.conf.rtsp_transport) > -1) {
+        argv.unshift(this.conf.rtsp_transport);
+        argv.unshift("-rtsp_transport");
+      }
+    }
+
+    Logger.log("[relay task] id=" + this.id, "cmd=ffmpeg", argv.join(" "));
+
+    this.ffmpeg_exec = spawn(this.conf.ffmpeg, argv);
+    this.ffmpeg_exec.on("error", (e) => {
+      Logger.ffdebug(e);
+    });
+
+    this.ffmpeg_exec.stdout.on("data", (data) => {
+      Logger.ffdebug(`FF_LOG:${data}`);
+    });
+
+    this.ffmpeg_exec.stderr.on("data", (data) => {
+      Logger.ffdebug(`FF_LOG:${data}`);
+    });
+
+    this.ffmpeg_exec.on("close", (code) => {
+      Logger.log("[relay end] id=" + this.id, "code=" + code);
+      this.emit("end", this.id);
+    });
+  }
+
+  end() {
+    this.ffmpeg_exec.kill();
+  }
+}
+
+module.exports = NodeRelaySession;


### PR DESCRIPTION
## Issue

- Resolves #29 

## Description

- H264 화면 송출 에러 수정
  - `node-media-server` 라이브러리 코드를 덮어쓰는 방식
- RTMP 서버 80 포트 추가

## Check List

- [X]  PR 제목을 커밋 규칙에 맞게 작성
- [X]  PR에 해당되는 Issue를 연결 완료
- [X]  적절한 라벨 설정
- [X]  작업한 사람 모두를 Assign
- [X]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [X]  "dev" 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
