### PR TITLE
[fix] 다크모드 로컬스토리지에 저장

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,12 +3,12 @@ import GlobalStyle from '@/styles/GlobalStyles.styles'
 import MainPage from '@/pages/MainPage/MainPage'
 import BroadcastPage from '@/pages/BroadcastPage/BroadcastPage'
 import { ThemeProvider } from 'styled-components'
-import { useRecoilValue } from 'recoil'
-import { themeState, ThemeFlag } from '@/states/theme'
 import { lightTheme, darkTheme } from '@/styles/theme'
+import useStoredTheme from '@/hooks/useStoredTheme'
+import { ThemeFlag } from './states/theme'
 
 function App() {
-  const currentTheme = useRecoilValue(themeState)
+  const currentTheme = useStoredTheme()
   const theme = currentTheme === ThemeFlag.light ? lightTheme : darkTheme
 
   return (

--- a/client/src/components/Modal/SettingModal/SettingModal.tsx
+++ b/client/src/components/Modal/SettingModal/SettingModal.tsx
@@ -15,6 +15,7 @@ const SettingModal = ({ onConfirm }: SettingModalProps) => {
 
   const toggleTheme = () => {
     setTheme(isDarkMode ? ThemeFlag.light : ThemeFlag.dark)
+    localStorage.setItem('theme', `${currentTheme}`)
   }
 
   return (

--- a/client/src/hooks/useStoredTheme.ts
+++ b/client/src/hooks/useStoredTheme.ts
@@ -1,0 +1,22 @@
+import { ThemeFlag, themeState } from '@/states/theme'
+import { useEffect } from 'react'
+import { useRecoilState } from 'recoil'
+
+function useStoredTheme() {
+  const [theme, setTheme] = useRecoilState(themeState)
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme') === `${ThemeFlag.light}` ? ThemeFlag.light : ThemeFlag.dark
+    if (storedTheme === ThemeFlag.light || storedTheme === ThemeFlag.dark) {
+      setTheme(storedTheme)
+    }
+  }, [setTheme])
+
+  useEffect(() => {
+    localStorage.setItem('theme', `${theme}`)
+  }, [theme])
+
+  return theme
+}
+
+export default useStoredTheme

--- a/client/src/states/theme.ts
+++ b/client/src/states/theme.ts
@@ -7,5 +7,5 @@ export enum ThemeFlag {
 
 export const themeState = atom<ThemeFlag>({
   key: 'THEME_STATE',
-  default: ThemeFlag.light,
+  default: localStorage.getItem('theme') === `${ThemeFlag.light}` ? ThemeFlag.light : ThemeFlag.dark,
 })


### PR DESCRIPTION
## Issue

- Resolves #111 

## Description

- 다크모드 값을 로컬스토리지에 저장해서 새로고침해도 변경되지 않게 구현
- useStoredTheme 커스텀훅 추가

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  "dev" 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot

https://github.com/boostcampwm2023/web07-GBS/assets/21211957/ff6df59a-8d73-49e4-82a7-69756bc2467a


