### PR TITLE
[feat] 유저 전역상태 만들기 & 로그인 하지 않은사람 채팅 막기

### DIFF
--- a/client/src/components/Modal/ConfirmModal/ConfirmModal.styles.tsx
+++ b/client/src/components/Modal/ConfirmModal/ConfirmModal.styles.tsx
@@ -1,0 +1,83 @@
+import styled from 'styled-components'
+import TYPO from '@/styles/typo/TYPO'
+import { ThemeFlag } from '@/states/theme'
+import { ThemeInterface } from '@/types/theme'
+
+export const Backdrop = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 10;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  text-align: center;
+`
+
+export const ModalContainer = styled(Backdrop)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`
+
+export const Modal = styled.div<ThemeInterface>`
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  border: ${(props) => {
+    if (props.currentTheme === ThemeFlag.light) return '0.0625rem solid #000000'
+    else return '0.0625rem solid #ffffff'
+  }};
+  box-shadow: 0.25rem 0.25rem 0.1875rem rgba(0, 0, 0, 0.1);
+  width: 22.5rem;
+  height: max-content;
+  background-color: ${(props) => {
+    if (props.currentTheme === ThemeFlag.dark) return '#999'
+    else return 'white'
+  }};
+  border-radius: 0.625rem;
+`
+
+export const BodyContainer = styled.div`
+  padding: 0.9375rem 1.875rem 0.9375rem 1.875rem;
+`
+
+export const HeaderText = styled.div`
+  ${TYPO.MEDIUM_M}
+  margin-bottom: 0.9375rem;
+  line-height: 2.25rem;
+`
+
+export const LoginImage = styled.img`
+  height: 4rem;
+  margin-bottom: 0.625rem;
+  cursor: pointer;
+`
+
+export const ButtonContainer = styled.div<ThemeInterface>`
+  ${TYPO.MEDIUM_M}
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-top: ${(props) => {
+    if (props.currentTheme === ThemeFlag.light) return '0.0625rem solid #000000'
+    else return '0.0625rem solid #ffffff'
+  }};
+  bottom: 0rem;
+  width: 100%;
+  height: 4.6875rem;
+`
+
+export const Button = styled.div`
+  ${TYPO.MEDIUM_M}
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+`

--- a/client/src/components/Modal/ConfirmModal/ConfirmModal.tsx
+++ b/client/src/components/Modal/ConfirmModal/ConfirmModal.tsx
@@ -2,13 +2,14 @@ import * as styles from './ConfirmModal.styles'
 import { ThemeFlag } from '@/states/theme'
 
 interface ConfirmModalProps {
-  onCancle: () => void
+  onConfrim: () => void
   currentTheme: ThemeFlag
+  text: string
 }
 
-const ConfirmModal = ({ onCancle, currentTheme }: ConfirmModalProps) => {
+const ConfirmModal = ({ onConfrim, currentTheme, text }: ConfirmModalProps) => {
   return (
-    <styles.Backdrop onClick={onCancle}>
+    <styles.Backdrop onClick={onConfrim}>
       <styles.ModalContainer>
         <styles.Modal
           onClick={(event) => {
@@ -17,10 +18,10 @@ const ConfirmModal = ({ onCancle, currentTheme }: ConfirmModalProps) => {
           currentTheme={currentTheme}
         >
           <styles.BodyContainer>
-            <styles.HeaderText>채팅을 입력하시려면 로그인을 먼저 해주세요!</styles.HeaderText>
+            <styles.HeaderText>{text}</styles.HeaderText>
           </styles.BodyContainer>
           <styles.ButtonContainer currentTheme={currentTheme}>
-            <styles.Button onClick={onCancle}>확인</styles.Button>
+            <styles.Button onClick={onConfrim}>확인</styles.Button>
           </styles.ButtonContainer>
         </styles.Modal>
       </styles.ModalContainer>

--- a/client/src/components/Modal/ConfirmModal/ConfirmModal.tsx
+++ b/client/src/components/Modal/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,30 @@
+import * as styles from './ConfirmModal.styles'
+import { ThemeFlag } from '@/states/theme'
+
+interface ConfirmModalProps {
+  onCancle: () => void
+  currentTheme: ThemeFlag
+}
+
+const ConfirmModal = ({ onCancle, currentTheme }: ConfirmModalProps) => {
+  return (
+    <styles.Backdrop onClick={onCancle}>
+      <styles.ModalContainer>
+        <styles.Modal
+          onClick={(event) => {
+            event.stopPropagation()
+          }}
+          currentTheme={currentTheme}
+        >
+          <styles.BodyContainer>
+            <styles.HeaderText>채팅을 입력하시려면 로그인을 먼저 해주세요!</styles.HeaderText>
+          </styles.BodyContainer>
+          <styles.ButtonContainer currentTheme={currentTheme}>
+            <styles.Button onClick={onCancle}>확인</styles.Button>
+          </styles.ButtonContainer>
+        </styles.Modal>
+      </styles.ModalContainer>
+    </styles.Backdrop>
+  )
+}
+export default ConfirmModal

--- a/client/src/pages/BroadcastPage/BroadcastPage.tsx
+++ b/client/src/pages/BroadcastPage/BroadcastPage.tsx
@@ -10,6 +10,8 @@ import ViewerModal from '@components/Modal/ViewerModal/ViewerModal'
 import Chatting from '@components/Chatting/Chatting'
 import { useRecoilValue } from 'recoil'
 import { themeState } from '@/states/theme'
+import { userState } from '@/states/user'
+import ConfirmModal from '@components/Modal/ConfirmModal/ConfirmModal'
 
 interface BroadcastProps {
   id: string
@@ -41,8 +43,10 @@ const BroadcastPage = () => {
   const [manager, setManager] = useState<Array<string>>([])
   const [chatting, setChatting] = useState<string>('')
   const [chattingList, setChattingList] = useState<Array<ChattingProps>>([])
+  const [isLoginCheckModal, setIsLoginCheckModal] = useState<boolean>(true)
   const socket = useRef<any>(null)
   const theme = useRecoilValue(themeState)
+  const user = useRecoilValue(userState)
 
   const onSetting = () => {
     setSettingModal(() => !settingModal)
@@ -140,7 +144,18 @@ const BroadcastPage = () => {
           ))}
         </styles.ChattingList>
         <styles.Input currentTheme={theme}>
-          <styles.Text currentTheme={theme} value={chatting} onChange={(event) => setChatting(event.target.value)} onKeyDown={onEnter}></styles.Text>
+          <styles.Text
+            currentTheme={theme}
+            value={chatting}
+            onChange={(event) => {
+              if (user.id === '') {
+                setIsLoginCheckModal(true)
+                return
+              }
+              return setChatting(event.target.value)
+            }}
+            onKeyDown={onEnter}
+          ></styles.Text>
           <styles.Send currentTheme={theme} onClick={onSend}>
             등록하기
           </styles.Send>
@@ -153,6 +168,14 @@ const BroadcastPage = () => {
       </styles.Info>
       {settingModal ? <SettingModal onConfirm={onSetting} /> : null}
       {loginModal ? <LoginModal onCancle={onLogin} currentTheme={theme} /> : null}
+      {isLoginCheckModal && (
+        <ConfirmModal
+          currentTheme={theme}
+          onCancle={() => {
+            setIsLoginCheckModal(false)
+          }}
+        />
+      )}
       {viewerModal ? (
         <ViewerModal
           nickname={viewerModalInfo.nickname}

--- a/client/src/pages/BroadcastPage/BroadcastPage.tsx
+++ b/client/src/pages/BroadcastPage/BroadcastPage.tsx
@@ -43,7 +43,7 @@ const BroadcastPage = () => {
   const [manager, setManager] = useState<Array<string>>([])
   const [chatting, setChatting] = useState<string>('')
   const [chattingList, setChattingList] = useState<Array<ChattingProps>>([])
-  const [isLoginCheckModal, setIsLoginCheckModal] = useState<boolean>(true)
+  const [isLoginCheckModal, setIsLoginCheckModal] = useState<boolean>(false)
   const socket = useRef<any>(null)
   const theme = useRecoilValue(themeState)
   const user = useRecoilValue(userState)

--- a/client/src/pages/BroadcastPage/BroadcastPage.tsx
+++ b/client/src/pages/BroadcastPage/BroadcastPage.tsx
@@ -44,6 +44,7 @@ const BroadcastPage = () => {
   const [chatting, setChatting] = useState<string>('')
   const [chattingList, setChattingList] = useState<Array<ChattingProps>>([])
   const [isLoginCheckModal, setIsLoginCheckModal] = useState<boolean>(false)
+  const [isEmptyChat, setIsEmptyChat] = useState<boolean>(false)
   const socket = useRef<any>(null)
   const theme = useRecoilValue(themeState)
   const user = useRecoilValue(userState)
@@ -95,7 +96,7 @@ const BroadcastPage = () => {
 
   const onSend = () => {
     if (chatting.trim() === '') {
-      alert('채팅을 입력해주세요.')
+      setIsEmptyChat(true)
     } else {
       socket.current.emit('chat', { message: chatting })
     }
@@ -171,8 +172,18 @@ const BroadcastPage = () => {
       {isLoginCheckModal && (
         <ConfirmModal
           currentTheme={theme}
-          onCancle={() => {
+          text="채팅을 입력하시려면 로그인을 먼저 해주세요"
+          onConfrim={() => {
             setIsLoginCheckModal(false)
+          }}
+        />
+      )}
+      {isEmptyChat && (
+        <ConfirmModal
+          currentTheme={theme}
+          text="채팅을 입력해주세요"
+          onConfrim={() => {
+            setIsEmptyChat(false)
           }}
         />
       )}

--- a/client/src/states/user.ts
+++ b/client/src/states/user.ts
@@ -1,0 +1,7 @@
+import { User } from '@/types/user'
+import { atom } from 'recoil'
+
+export const userState = atom<User>({
+  key: 'USER_STATE',
+  default: { id: '', nickname: '' },
+})

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: string
+  nickname: string
+}


### PR DESCRIPTION
## Issue

- Resolves #96, #115

## Description

- recoil을 이용한 유저 전역상태 구현
- 로그인 하지 않은 사람은 채팅 입력하려고 할 때 경고 모달 띄우게 구현

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  "dev" 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot

https://github.com/boostcampwm2023/web07-GBS/assets/21211957/5634390a-91ef-4933-9165-ff98e7600a9a


