### PR TITLE
[fix] 방송 정보를 가져오지 못하는 버그 수정

### DIFF
--- a/server/rtmp-server/nginx.conf
+++ b/server/rtmp-server/nginx.conf
@@ -8,8 +8,6 @@ rtmp {
         application live {
             live on;
 
-            notify_relay_redirect on;
-
             # on_publish_url
         }
     }


### PR DESCRIPTION
## Issue

- close #125 

## Description

- RTMP 서버에서 `notify_relay_redirect on;` 옵션으로 stream name이 변경되고 있어 옵션을 지웠고 로컬에서 잘 동작하는 것을 확인했습니다.

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  "dev" 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
