### PR TITLE
[fix] RTMP 모듈에서 HTTPS를 지원하지 않아 발생한 문제 해결

### DIFF
--- a/server/api-server/package.json
+++ b/server/api-server/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
+    "start": "NODE_ENV=production nest start",
     "start:dev": "NODE_ENV=development nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "NODE_ENV=production node dist/main",

--- a/server/api-server/src/main.ts
+++ b/server/api-server/src/main.ts
@@ -19,6 +19,12 @@ async function bootstrap() {
     httpsOptions,
   });
 
+  app.enableCors({
+    origin: process.env.CLIENT_ORIGIN,
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    credentials: true,
+  });
+
   const session = getSession();
   app.use(session);
   app.use(passport.initialize());


### PR DESCRIPTION
## Issue

- close #130 

## Description

- HTTP/HTTPS 모두 가능하도록 수정
  - 채팅도 정상 동작합니다.

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  "dev" 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
